### PR TITLE
Fix wording on how properties go down the chain, not up

### DIFF
--- a/slides-js-prototypes.html
+++ b/slides-js-prototypes.html
@@ -227,11 +227,11 @@ reignInBlood.play(); // 'playing'
 </div></div>
 <div class="sl-block" data-block-type="text" data-block-id="3225bccefc7d29b8745838c64ec7ffb5" style="height: auto; min-width: 30px; min-height: 30px; width: 600px; left: 180px; top: 82px;"><div class="sl-block-content" data-placeholder-tag="p" data-placeholder-text="Text" style="z-index: 12;">
 <ul>
-	<li><span style="font-size:24px">All objects that inherit from another object receive all prototype properties of all objects up the prototype chain</span></li>
-	<li><span style="font-size:24px">Adding to a prototype anywhere in the prototype chain will add property all the way up the chain.</span></li>
+	<li><span style="font-size:24px">All objects that inherit from another object receive all prototype properties of all objects up the prototype chain.</span></li>
+	<li><span style="font-size:24px">Adding to a prototype object will pass its properties all the way down the chain.</span></li>
 	<li><span style="font-size:24px">hasOwnProperty() will tell you if the method is defined on the current object or inherited.</span></li>
 	<li><span style="font-size:24px">Inheritance ONLY inherits prototypes not constructor methods.</span></li>
-	<li><span style="font-size:24px">Example: forEach example to support legacy browsers</span></li>
+	<li><span style="font-size:24px">Example: forEach example to support legacy browsers.</span></li>
 </ul>
 </div></div>
 <div class="sl-block" data-block-type="code" data-block-id="a84b6eb70595917b3448fbb5a072acce" style="min-width: 30px; min-height: 30px; width: 648px; height: 156px; left: 160px; top: 524px;"><div class="sl-block-content" style="z-index: 13;"><pre><code>if (!Array.prototype.forEach) {


### PR DESCRIPTION
Wording is a little confusing since the slides use "up the chain" to refer to going towards the `Object.prototype` object. Adding to a prototype object passes properties _down_ to its children.
